### PR TITLE
Add support for username destination type in conference and TTS callouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,4 @@ $RECYCLE.BIN/
 .vs/
 project.lock.json
 *.xproj.user
+*.csproj.user

--- a/Examples/Sinch.Callout.Example/Program.cs
+++ b/Examples/Sinch.Callout.Example/Program.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Sinch.ServerSdk;
 using Sinch.ServerSdk.Calling.Callbacks.Response;
+using Sinch.ServerSdk.Callouts;
 using Sinch.ServerSdk.IvrMenus;
 
 namespace Sinch.Callout.Example
@@ -20,6 +21,12 @@ namespace Sinch.Callout.Example
             // TTS callout
             var calloutResponse = await calloutApi.TtsCallout("+15612600684", "How are you doing?", "").Call();
             
+            Console.WriteLine(calloutResponse.callId);
+            Console.ReadLine();
+
+            // Conference callout
+            calloutResponse = await calloutApi.ConferenceCallout(To.Username("Buddy"), "ConfId-123", "", "Welcome!").Call();
+
             Console.WriteLine(calloutResponse.callId);
             Console.ReadLine();
 

--- a/src/Sinch.ServerSdk/Callouts/CalloutApi.cs
+++ b/src/Sinch.ServerSdk/Callouts/CalloutApi.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Sinch.ServerSdk.IvrMenus;
-using Sinch.ServerSdk.Models;
 
 namespace Sinch.ServerSdk.Callouts
 {
@@ -17,6 +16,21 @@ namespace Sinch.ServerSdk.Callouts
 
         public ICalloutRequest TtsCallout(string to, string message, string from, string dtmf)
         {
+            return TtsCallout(To.Number(to), message, from, dtmf);
+        }
+
+        public ICalloutRequest TtsCallout(string to, string message, string from)
+        {
+            return TtsCallout(To.Number(to), message, from, "");
+        }
+
+        public ICalloutRequest TtsCallout(To to, string message, string from)
+        {
+            return TtsCallout(to, message, from, "");
+        }
+
+        public ICalloutRequest TtsCallout(To to, string message, string from, string dtmf)
+        {
             var request = _request;
             request.Method = "ttsCallout";
 
@@ -24,24 +38,30 @@ namespace Sinch.ServerSdk.Callouts
             {
                 Dtmf = dtmf,
                 Cli = @from,
-                Destination = new IdentityModel()
-                {
-                    Endpoint = to,
-                    Type = "number"
-                },
+                Domain = to.Domain,
+                Destination = to.ToIdentity(),
                 Prompts = "#tts[" + message + "]"
             };
 
             return request;
         }
-        public ICalloutRequest TtsCallout(string to, string message, string from)
-        {
-            return TtsCallout(to, message, from, "");
-        }
-
-     
 
         public ICalloutRequest ConferenceCallout(string to, string conferenceId, string from, string greeting, string dtmf)
+        {
+            return ConferenceCallout(To.Number(to), conferenceId, from, greeting, dtmf);
+        }
+
+        public ICalloutRequest ConferenceCallout(string to, string conferenceId, string from, string greeting)
+        {
+            return ConferenceCallout(To.Number(to), conferenceId, from, greeting, "");
+        }
+
+        public ICalloutRequest ConferenceCallout(To to, string conferenceId, string from, string greeting)
+        {
+            return ConferenceCallout(to, conferenceId, from, greeting, "");
+        }
+
+        public ICalloutRequest ConferenceCallout(To to, string conferenceId, string from, string greeting, string dtmf)
         {
             var request = _request;
             request.Method = "conferenceCallout";
@@ -51,34 +71,26 @@ namespace Sinch.ServerSdk.Callouts
                 Dtmf = dtmf,
                 ConferenceId = conferenceId,
                 Cli = @from,
-                Destination = new IdentityModel()
-                {
-                    Type = "number",
-                    Endpoint = to
-                },
+                Domain = to.Domain,
+                Destination = to.ToIdentity(),
                 Greeting = greeting
             };
 
             return request;
         }
 
-      
-
-        public ICalloutRequest ConferenceCallout(string to, string conferenceId, string from, string greeting)
-        {
-            return ConferenceCallout(to, conferenceId, from, greeting, "");
-        }
         public ICalloutRequest MenuCallout(string to, string from, IMenuBuilder menu, string startMenu, TimeSpan? maxDuration)
         {
             return MenuCallout(to, from, menu, startMenu, maxDuration, "");
         }
-        public ICalloutRequest MenuCallout(string to, string @from, IMenuBuilder menu, string startMenu, TimeSpan? maxDuration = null, string dtmf="")
+
+        public ICalloutRequest MenuCallout(string to, string @from, IMenuBuilder menu, string startMenu, TimeSpan? maxDuration = null, string dtmf = "")
         {
             TimeSpan waittime = (maxDuration == null ? TimeSpan.FromSeconds(10) : (TimeSpan)maxDuration);
 
             var request = _request;
             request.Method = "customCallout";
-            
+
             request.CustomCallout = new CustomCalloutCalloutRequest
             {
                 Ice = _responseFactory.CreateIceSvamletBuilder().ConnectPstn(to).WithDTMF(dtmf).WithCli(@from).WithBridgeTimeout(waittime).Body,
@@ -93,13 +105,5 @@ namespace Sinch.ServerSdk.Callouts
         {
             return new MenuBuilder();
         }
-
- 
-
-
-   
-
-   
-
     }
 }

--- a/src/Sinch.ServerSdk/Callouts/ICalloutApi.cs
+++ b/src/Sinch.ServerSdk/Callouts/ICalloutApi.cs
@@ -1,5 +1,4 @@
 using System;
-using Sinch.ServerSdk.Calling.Callbacks.Response;
 using Sinch.ServerSdk.IvrMenus;
 
 namespace Sinch.ServerSdk.Callouts
@@ -8,8 +7,15 @@ namespace Sinch.ServerSdk.Callouts
     {
         ICalloutRequest TtsCallout(string to, string message, string from);
         ICalloutRequest TtsCallout(string to, string message, string from, string dtmf);
+
+        ICalloutRequest TtsCallout(To to, string message, string from);
+        ICalloutRequest TtsCallout(To to, string message, string from, string dtmf);
+
         ICalloutRequest ConferenceCallout(string to, string conferenceId, string from, string greeting);
         ICalloutRequest ConferenceCallout(string to, string conferenceId, string from, string greeting, string dtmf);
+
+        ICalloutRequest ConferenceCallout(To to, string conferenceId, string from, string greeting);
+        ICalloutRequest ConferenceCallout(To to, string conferenceId, string from, string greeting, string dtmf);
 
         ICalloutRequest MenuCallout(string to, string from, IMenuBuilder menu, string startMenu, TimeSpan? maxDuration);
         ICalloutRequest MenuCallout(string to, string from, IMenuBuilder menu, string startMenu, TimeSpan? maxDuration, string dtmf);

--- a/src/Sinch.ServerSdk/Callouts/To.cs
+++ b/src/Sinch.ServerSdk/Callouts/To.cs
@@ -1,0 +1,48 @@
+﻿using Sinch.ServerSdk.Models;
+
+namespace Sinch.ServerSdk.Callouts
+{
+    /// <summary>
+    /// Defines callout destination
+    /// </summary>
+    public sealed class To
+    {
+        public string Type { get; }
+
+        public string Domain { get; }
+
+        private string Endpoint { get; }
+
+        private To(string type, string domain, string endpoint)
+        {
+            Type = type;
+            Domain = domain;
+            Endpoint = endpoint;
+        }
+
+        /// <summary>
+        /// Get PSTN callout destination
+        /// </summary>
+        /// <param name="number">Valid phone number</param>
+        /// <returns>PSTN destination</returns>
+        public static To Number(string number)
+        {
+            return new To("number", "pstn", number);
+        }
+
+        /// <summary>
+        /// Get data endpoint destination
+        /// </summary>
+        /// <param name="username">Username</param>
+        /// <returns>MXP destination</returns>
+        public static To Username(string username)
+        {
+            return new To("username", "mxp", username);
+        }
+
+        internal IdentityModel ToIdentity()
+        {
+            return new IdentityModel { Type = Type, Endpoint = Endpoint };
+        }
+    }
+}


### PR DESCRIPTION
Now `ICalloutApi` allows to perform [conference or TTS callout](https://developers.sinch.com/docs/voice-rest-api-calling-api#section-conference-and-text-to-speech-callouts) to _username_.

Resolves #4 

