### PR TITLE
Remove trailing forward slash from calling/v1/callouts API because of…

### DIFF
--- a/src/Sinch.ServerSdk/Callouts/ICalloutApiEndpoints.cs
+++ b/src/Sinch.ServerSdk/Callouts/ICalloutApiEndpoints.cs
@@ -4,6 +4,6 @@ using Sinch.WebApiClient;
 
 public interface ICalloutApiEndpoints
 {
-    [HttpPost("calling/v1/callouts/")]
+    [HttpPost("calling/v1/callouts")]
     Task<CalloutResponse> Callout([ToBody] CalloutRequest request);
 }


### PR DESCRIPTION
… AWS API Gateway compatibility

AWS API Gateway removes trailing slashes from URLs which may cause the request hash to be altered. This becomes a problem with the signature.

@bjofra 