### PR TITLE
Remove API route trailing slash to avoid AWS API Gateway modification

### DIFF
--- a/src/Sinch.ServerSdk/Callouts/ICalloutApiEndpoints.cs
+++ b/src/Sinch.ServerSdk/Callouts/ICalloutApiEndpoints.cs
@@ -4,6 +4,6 @@ using Sinch.WebApiClient;
 
 public interface ICalloutApiEndpoints
 {
-    [HttpPost("calling/v1/callouts/")]
+    [HttpPost("calling/v1/callouts")]
     Task<CalloutResponse> Callout([ToBody] CalloutRequest request);
 }


### PR DESCRIPTION
Remove last slash in API route  so url don't get modified when passing AWS API Gateway. This may be cause of signature error