### PR TITLE
Answering machine detection support in ICE response

### DIFF
--- a/Examples/CallingCallback/Program.cs
+++ b/Examples/CallingCallback/Program.cs
@@ -41,7 +41,8 @@ namespace Sinch.ServerSdk.Examples.CallingCallback
                         .WithBridgeTimeout(TimeSpan.FromMinutes(2.5))
                         .WithAnonymousCli()
                         .WithCallTag(CallTag.DefaultBillingTag, "C02-14")
-                        .WithCallTag("CustomCallTag", "foo").Body;
+                        .WithCallTag("CustomCallTag", "foo")
+                        .WithAnsweringMachineDetection().Body;
 
                 Console.WriteLine(iceResponseText);
             }

--- a/src/Sinch.ServerSdk/Calling/Callbacks/Response/IConnectPstnSvamletResponse.cs
+++ b/src/Sinch.ServerSdk/Calling/Callbacks/Response/IConnectPstnSvamletResponse.cs
@@ -17,5 +17,6 @@ namespace Sinch.ServerSdk.Calling.Callbacks.Response
         IConnectPstnSvamletResponse WithoutRecording();
         IConnectPstnSvamletResponse WithCallTag(CallTag tagType, string value);
         IConnectPstnSvamletResponse WithDTMF(string dtmf);
+        IConnectPstnSvamletResponse WithAnsweringMachineDetection();
     }
 }

--- a/src/Sinch.ServerSdk/Calling/Callbacks/Response/Internal/ConnectPstnSvamletResponse.cs
+++ b/src/Sinch.ServerSdk/Calling/Callbacks/Response/Internal/ConnectPstnSvamletResponse.cs
@@ -16,6 +16,12 @@ namespace Sinch.ServerSdk.Calling.Callbacks.Response.Internal
             return this;
         }
 
+        public IConnectPstnSvamletResponse WithAnsweringMachineDetection()
+        {
+            Model.Action.Amd = new AmdOptions {Enabled = true};
+            return this;
+        }
+
         public IConnectPstnSvamletResponse WithBridgeTimeout(TimeSpan timeout)
         {
             if (timeout.TotalMinutes > 240)

--- a/src/Sinch.ServerSdk/Calling/Models/AmdOptions.cs
+++ b/src/Sinch.ServerSdk/Calling/Models/AmdOptions.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace Sinch.ServerSdk.Calling.Models
+{
+    public class AmdOptions
+    {
+        [JsonProperty(PropertyName = "enabled")]
+        public bool Enabled { get; set; }
+    }
+}

--- a/src/Sinch.ServerSdk/Calling/Models/SvamletActionModel.cs
+++ b/src/Sinch.ServerSdk/Calling/Models/SvamletActionModel.cs
@@ -87,7 +87,7 @@ namespace Sinch.ServerSdk.Calling.Models
         [JsonProperty(PropertyName = "tags", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public KeyValueModel[] CallTags { get; set; }
 
-        [JsonProperty(PropertyName = "amd")]
+        [JsonProperty(PropertyName = "amd", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public AmdOptions Amd { get; set; }
     }
 }

--- a/src/Sinch.ServerSdk/Calling/Models/SvamletActionModel.cs
+++ b/src/Sinch.ServerSdk/Calling/Models/SvamletActionModel.cs
@@ -86,5 +86,8 @@ namespace Sinch.ServerSdk.Calling.Models
 
         [JsonProperty(PropertyName = "tags", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public KeyValueModel[] CallTags { get; set; }
+
+        [JsonProperty(PropertyName = "amd")]
+        public AmdOptions Amd { get; set; }
     }
 }


### PR DESCRIPTION
Adding support in ICE callback response for enabling answering machine detection when terminating to PSTN.