### PR TITLE
Adding voice-ivr support in menus

### DIFF
--- a/src/Sinch.ServerSdk/Calling/Callbacks/Response/IBridgedCallerSvamletBuilder.cs
+++ b/src/Sinch.ServerSdk/Calling/Callbacks/Response/IBridgedCallerSvamletBuilder.cs
@@ -11,5 +11,6 @@ namespace Sinch.ServerSdk.Calling.Callbacks.Response
         IConnectSipSvamletResponse ConnectRegisteredSipPeer(string authName);
         IConnectMxpSvamletResponse ConnectMxp(IIdentity identity);
         ISvamletResponse RunMenu(string menuId, IMenuBuilder menuBuilder);
+        ISvamletResponse RunMenu(string menuId, bool enableVoice, IMenuBuilder menuBuilder);
     }
 }

--- a/src/Sinch.ServerSdk/Calling/Models/MenuOptionModel.cs
+++ b/src/Sinch.ServerSdk/Calling/Models/MenuOptionModel.cs
@@ -8,6 +8,9 @@ namespace Sinch.ServerSdk.Calling.Models
         [JsonProperty(PropertyName = "dtmf", NullValueHandling = NullValueHandling.Ignore)]
         public string Digit { get; set; }
 
+        [JsonProperty(PropertyName = "input", NullValueHandling = NullValueHandling.Ignore)]
+        public string Input { get; set; }
+
         [JsonProperty(PropertyName = "action")]
         public string Action { get; set; }
 

--- a/src/Sinch.ServerSdk/Calling/Models/SvamletActionModel.cs
+++ b/src/Sinch.ServerSdk/Calling/Models/SvamletActionModel.cs
@@ -60,6 +60,9 @@ namespace Sinch.ServerSdk.Calling.Models
         [JsonProperty(PropertyName = "barge", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public bool Barge { get; set; }
 
+        [JsonProperty(PropertyName = "enableVoice", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public bool? EnableVoice { get; set; }
+
         [JsonProperty(PropertyName = "hangupCause", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public int HangupCause { get; set; }
 

--- a/src/Sinch.ServerSdk/IvrMenus/IMenu.cs
+++ b/src/Sinch.ServerSdk/IvrMenus/IMenu.cs
@@ -6,7 +6,9 @@ namespace Sinch.ServerSdk.IvrMenus
     public interface IMenu
     {
         IMenu AddGotoMenuOption(Dtmf option, string targetMenuId, IDictionary<string,string> cookies = null);
+        IMenu AddGotoMenuOption(string option, string targetMenuId, IDictionary<string, string> cookies = null);
         IMenu AddTriggerPieOption(Dtmf option, string result);
+        IMenu AddTriggerPieOption(string option, string result);
         IMenu WithRepeatPrompt(Prompt prompt);
         IMenu WithRepeats(int repeats);
         IMenuBuilder EndMenuDefinition();

--- a/src/Sinch.ServerSdk/IvrMenus/Menu.cs
+++ b/src/Sinch.ServerSdk/IvrMenus/Menu.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Sinch.ServerSdk.Calling.Callbacks.Response;
+using Sinch.ServerSdk.Callouts;
 
 namespace Sinch.ServerSdk.IvrMenus
 {
@@ -8,32 +9,53 @@ namespace Sinch.ServerSdk.IvrMenus
     {
         private readonly IMenuBuilder _builder;
 
-        public IDictionary<Dtmf,Tuple<string,IDictionary<string,string>>> GotoMenuOptions { get;  }
-        public IDictionary<Dtmf,string> ReturnOptions { get; }
+        public IDictionary<MenuOption,Tuple<string,IDictionary<string,string>>> GotoMenuOptions { get;  }
+        public IDictionary<MenuOption, string> ReturnOptions { get; }
 
         internal Menu(IMenuBuilder builder, Prompt prompt, Prompt repeatPrompt, int repeats, TimeSpan? timeout)
             : base(prompt, repeatPrompt, repeats, timeout)
         {
             _builder = builder;
 
-            GotoMenuOptions = new Dictionary<Dtmf, Tuple<string, IDictionary<string, string>>>();
-            ReturnOptions = new Dictionary<Dtmf, string>();
+            GotoMenuOptions = new Dictionary<MenuOption, Tuple<string, IDictionary<string, string>>>();
+            ReturnOptions = new Dictionary<MenuOption, string>();
         }
 
-        public IMenu AddGotoMenuOption(Dtmf option, string targetMenuId, IDictionary<string,string> cookies = null)
+        public IMenu AddGotoMenuOption(Dtmf option, string targetMenuId, IDictionary<string, string> cookies = null)
+        {
+            return AddGotoMenuOption((MenuOption)option, targetMenuId, cookies);
+        }
+
+        public IMenu AddGotoMenuOption(string option, string targetMenuId, IDictionary<string,string> cookies = null)
+        {
+            return AddGotoMenuOption((MenuOption)option, targetMenuId, cookies);
+        }
+
+        private IMenu AddGotoMenuOption(MenuOption option, string targetMenuId, IDictionary<string, string> cookies = null)
         {
             CheckClash(option);
-            GotoMenuOptions[option] = new Tuple<string, IDictionary<string, string>>(targetMenuId,cookies);
+            GotoMenuOptions[option] = new Tuple<string, IDictionary<string, string>>(targetMenuId, cookies);
+
             return this;
         }
 
-        private void CheckClash(Dtmf option)
+        private void CheckClash(MenuOption option)
         {
             if(GotoMenuOptions.ContainsKey(option) || ReturnOptions.ContainsKey(option))
                 throw new BuilderException("Option '" + option + "' already defined");
         }
 
         public IMenu AddTriggerPieOption(Dtmf option, string result)
+        {
+            return AddTriggerPieOption((MenuOption)option, result);
+        }
+
+        public IMenu AddTriggerPieOption(string option, string result)
+        {
+            return AddTriggerPieOption((MenuOption) option, result);
+        }
+
+        public IMenu AddTriggerPieOption(MenuOption option, string result)
         {
             CheckClash(option);
             ReturnOptions[option] = result;
@@ -55,6 +77,92 @@ namespace Sinch.ServerSdk.IvrMenus
         public IMenuBuilder EndMenuDefinition()
         {
             return _builder;
+        }
+    }
+
+    internal class MenuOption
+    {
+        private readonly Dtmf? _dtmf;
+        private readonly string _input;
+
+        public MenuOption(Dtmf dtmf)
+        {
+            _dtmf = dtmf;
+            _input = null;
+        }
+
+        public MenuOption(string input)
+        {
+            if (input == null)
+                throw new ArgumentNullException(nameof(input));
+
+            _dtmf = input.TryMapToDtmf();
+            // if dtmf is successfully parsed, treat this option as dtmf
+            // reasoning is that input is always populated with the same value
+            // as the dtmf, but if dtmf is missing, then only input is used
+            _input = _dtmf == null ? input : null;
+        }
+
+        public override int GetHashCode()
+        {
+            return _input?.GetHashCode() ?? _dtmf.GetHashCode();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (!(obj is MenuOption other))
+                return false;
+
+            return 
+                (other._input != null && _input != null && _input.Equals(other._input)) ||
+                (other._input == null && _input == null && _dtmf.Equals(other._dtmf));
+        }
+
+        public string Dtmf
+        {
+            get
+            {
+                if (_dtmf == null)
+                    return null;
+
+                return TypeMapper.Singleton.AsString((Dtmf) _dtmf);
+            }
+        }
+
+        public string Input => Dtmf ?? _input;
+
+        public override string ToString()
+        {
+            return Input;
+        }
+
+        public static implicit operator MenuOption(string input)
+        {
+            return new MenuOption(input);
+        }
+
+        public static implicit operator MenuOption(Dtmf dtmf)
+        {
+            return new MenuOption(dtmf);
+        }
+    }
+
+    internal static class StringExtensions
+    {
+        public static Dtmf? TryMapToDtmf(this string value)
+        {
+            if (value == null || value.Length != 1)
+                return null;
+
+            var digit = value[0];
+
+            if (digit == '*')
+                return Dtmf.Asterisk;
+
+            if (digit == '#')
+                return Dtmf.Hash;
+
+            return byte.TryParse(value, out var dtmf) ? (Dtmf) dtmf : default(Dtmf?);
         }
     }
 }

--- a/src/Sinch.ServerSdk/IvrMenus/MenuBuilder.cs
+++ b/src/Sinch.ServerSdk/IvrMenus/MenuBuilder.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Sinch.ServerSdk.Calling.Callbacks.Response;
 using Sinch.ServerSdk.Calling.Models;
 using Sinch.ServerSdk.Models;
 
@@ -12,9 +13,6 @@ namespace Sinch.ServerSdk.IvrMenus
 
         private readonly IDictionary<string, NumberInputMenu> _numberInputMenus =
             new Dictionary<string, NumberInputMenu>();
-
-        private TypeMapper Mapper { get; } = new TypeMapper();
-
 
         public IMenu BeginMenuDefinition(string menuId, Prompt prompt, TimeSpan? timeout)
         {
@@ -68,11 +66,13 @@ namespace Sinch.ServerSdk.IvrMenus
                         mo.Value.Item2 != null
                             ? mo.Value.Item2.Select(c => new KeyValueModel {Key = c.Key, Value = c.Value}).ToArray()
                             : null,
-                    Digit = Mapper.AsString(mo.Key)
+                    Digit = mo.Key.Dtmf,
+                    Input = mo.Key.Input
                 }).Union(m.Value.ReturnOptions.Select(ro => new MenuOptionModel()
                 {
                     Action = "return(" + ro.Value + ")",
-                    Digit = Mapper.AsString(ro.Key),
+                    Digit = ro.Key.Dtmf,
+                    Input = ro.Key.Input
                 }));
 
                 menu.Options = options.ToArray();


### PR DESCRIPTION
Added support for enabling voice assisted menus when responding to an ICE or ACE callback request.

- Added a new overload when "attaching" the menu to the SVAML action, where `enableVoice` can be specified
- Added overloads in the `IMenu` interface allowing options that are not strictly DTMF digits
  * please review the `option` argument of `AddGotoMenuOption` and `AddTriggerPieOption` - I was thinking that it might be called `voiceOption`, but it doesn't fit perfectly because if only `input` is specified in the SVAML and DTMF is used, it will be matched, i.e. the `input` property matches both DTMF and voice inputs (afaik)
- Added a check when "attaching" the menu to the SVAML action to verify that the voice options are not used when `enableVoice` is `false`
- When `enableVoice` is `false`, the `input` fields are nullified